### PR TITLE
Sync slider add-more button with available stock

### DIFF
--- a/assets/collection-quick-add.js
+++ b/assets/collection-quick-add.js
@@ -45,8 +45,8 @@ function qgSyncSliderQtyUI(qtyEl, sendQty) {
 
   var step = parseInt(qtyEl.getAttribute('data-collection-min-qty') || qtyEl.step || '1', 10) || 1;
   var max  = parseInt(qtyEl.getAttribute('max') || qtyEl.max || '0', 10) || 0;
-  var lowStock  = (max > 0 && max < step);
-  var highlight = lowStock && sendQty >= max;
+  var atMax = isFinite(max) && sendQty >= max;
+  var highlight = max > 0 && sendQty >= max;
 
   // highlight cand se atinge stocul disponibil
   qtyEl.classList.toggle('text-red-600', highlight);
@@ -61,7 +61,7 @@ function qgSyncSliderQtyUI(qtyEl, sendQty) {
   if (wrap) {
     var plus  = wrap.querySelector('[data-collection-quantity-selector="increase"]');
     var minus = wrap.querySelector('[data-collection-quantity-selector="decrease"]');
-    if (plus)  plus.disabled  = isFinite(max) && sendQty >= max;
+    if (plus)  plus.disabled  = atMax;
     if (minus) minus.disabled = sendQty <= step;
   }
 
@@ -69,7 +69,8 @@ function qgSyncSliderQtyUI(qtyEl, sendQty) {
   var card = qtyEl.closest('.sf__pcard, .p-card, .product-card, .sf__col-item, [data-product-id], .swiper-slide, [data-section-type]');
   var dbl  = card && (card.querySelector('[data-collection-double-qty]') || card.querySelector('.collection-double-qty-btn') || card.querySelector('.double-qty-btn'));
   if (dbl) {
-    var disabled = lowStock; // cand stoc < min_qty, dezactivat
+    var disabled = atMax;
+    dbl.disabled = disabled;
     dbl.toggleAttribute('disabled', disabled);
     dbl.setAttribute('aria-disabled', String(disabled));
     dbl.classList.toggle('is-disabled', disabled);


### PR DESCRIPTION
## Summary
- Remove low stock check from `qgSyncSliderQtyUI` so "Add more" button only disables at actual stock limits

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c7c7e92b4832daf0b56165303222c