### PR TITLE
Fix wishlist quantity to honor manual values below minimum

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -10149,6 +10149,10 @@ class Wishlist {
         }
 
         container.classList.add('opacity-100');
+
+        if (!noItemAvailable) {
+          window.dispatchEvent(new Event('shopify:product:updated'));
+        }
       }
     });
 


### PR DESCRIPTION
## Summary
- reinitialize product scripts after wishlist products load so manually entered quantities under the product minimum are kept

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cbde978f0832d991c89506c55374e