### PR TITLE
Allow quantity below minimum on collection and wishlist

### DIFF
--- a/assets/collection-quick-add.js
+++ b/assets/collection-quick-add.js
@@ -397,10 +397,8 @@ function qgSyncSliderQtyUI(qtyEl, sendQty) {
     var qtyEl = findQtyEl(baseCard);
     var val = parseInt(qtyEl && (qtyEl.value || qtyEl.getAttribute('value')) || '1',10);
     if(!isFinite(val) || val < 1) val = 1;
-    var step = parseInt(qtyEl && (qtyEl.getAttribute('data-collection-min-qty') || qtyEl.step || '1'),10) || 1;
-    var min = parseInt(qtyEl && (qtyEl.getAttribute('data-collection-min-qty') || qtyEl.min || step || '1'),10) || 1;
     var max = parseInt(qtyEl && (qtyEl.max || '999999'),10) || 999999;
-    val = clampAndSnap(val, step, min, max, true);
+    if(val > max) val = max;
     return { val: val, baseCard: baseCard, qtyEl: qtyEl };
   }
   function findQtyInput(btn){


### PR DESCRIPTION
## Summary
- allow manual quantities below product minimum when adding from collection or wishlist

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ccdf28548832dab8dd2fc60d1b67d